### PR TITLE
Backport "Restrict initial location for ACTION_OPEN_DOCUMENT/_TREE" from AOSP

### DIFF
--- a/src/com/android/documentsui/util/FileUtils.java
+++ b/src/com/android/documentsui/util/FileUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.documentsui.util;
+
+import androidx.annotation.NonNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+
+public class FileUtils {
+
+    /**
+     * Returns the canonical pathname string of the provided abstract pathname.
+     *
+     * @return The canonical pathname string denoting the same file or directory as this abstract
+     *         pathname.
+     * @see File#getCanonicalPath()
+     */
+    @NonNull
+    public static String getCanonicalPath(@NonNull String path) throws IOException {
+        Objects.requireNonNull(path);
+        return new File(path).getCanonicalPath();
+    }
+
+    /**
+     * This is basically a very slightly tweaked fork of
+     * {@link com.android.externalstorage.ExternalStorageProvider#getPathFromDocId(String)}.
+     * The difference between this fork and the "original" method is that here we do not strip
+     * the leading and trailing "/"s (because we don't worry about those).
+     *
+     * @return canonicalized file path.
+     */
+    public static String getPathFromStorageDocId(String docId) throws IOException {
+        // Remove the root tag from the docId, e.g. "primary:", which should leave with the file
+        // path.
+        final String docIdPath = docId.substring(docId.indexOf(':', 1) + 1);
+
+        return getCanonicalPath(docIdPath);
+    }
+
+    private FileUtils() {
+    }
+}


### PR DESCRIPTION
Implement privacy restriction introduced in Android 11 that application are not allowed to request initial location for intent actions ACTION_OPEN_DOCUMENT and ACTION_OPEN_DOCUMENT_TREE to be /Android/data/, /Android/obb/, /Android/sandbox/ and all their subdirectories. If an application does request the initial location to be one of these directories (or their subdirs) redirect to the default location - last accessed stack.

Bug: 200034476
Bug: 220066255
Test: atest
  DocumentsUIGoogleTests:com.android.documentsui.picker.ActionHandlerTest
Test: adb shell am start
  -a android.intent.action.OPEN_DOCUMENT_TREE
  --eu android.provider.extra.INITIAL_URI
  "content://com.android.externalstorage.documents/document/primary%3AAndroid%2Fdata"
Change-Id: I7e31a8fb76b5ddb0e3af67852b1e1ccc9a825648