### PR TITLE
14 QPR2: fix file (un)compression support

### DIFF
--- a/proguard.flags
+++ b/proguard.flags
@@ -25,3 +25,6 @@
 # To prevent class not found exception in org.brotli.dec.Dictionary
 -keep final class org.brotli.dec.DictionaryData
 
+-keepclassmembers class org.apache.commons.compress.archivers.** {
+   <init>(...);
+}


### PR DESCRIPTION
R8 in 14 QPR2 removes class constructors that are called via reflection if they are otherwise unused.

In DocumentsUI, this breaks code in its apache-commons-compress dependency, which breaks file (un)compression functionality.

See static initializer of org.apache.commons.compress.archivers.zip.ExtraFieldUtils for more info.