### PR TITLE
fix NPE crash after activity state restoration

### DIFF
--- a/src/com/android/documentsui/BaseActivity.java
+++ b/src/com/android/documentsui/BaseActivity.java
@@ -464,6 +464,7 @@ public abstract class BaseActivity
             if (DEBUG) {
                 Log.d(mTag, "Recovered existing state object: " + state);
             }
+            state.configStore = mConfigStore;
             return state;
         }
 


### PR DESCRIPTION
configStore is not restored when the State object is unparcelled.