### PR TITLE
Add ACCESS_MEDIA_LOCATION permission

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -49,6 +49,8 @@
     <!-- Permissions required for reading device configs -->
     <uses-permission android:name="android.permission.READ_DEVICE_CONFIG"/>
 
+    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
+
     <!-- Declaring the permission for apps wanting to launch DocsUI through the home screen. -->
     <permission
         android:name="com.android.documentsui.LAUNCH_FILE_MANAGER"


### PR DESCRIPTION
MediaProvider strips out location EXIF tags by default for apps without this permission. This makes it impossible to do a lossless file copy or file move that requires copy + delete for image files.

Adding this permission allows the user to choose whether or not to redact EXIF location, albeit with no convenient in-app UI toggle.

Fixes: https://github.com/GrapheneOS/os-issue-tracker/issues/8548

---

This shouldn't have any bearing on what apps see when they use DocumentsUI's SAF file pickers. I made a small sample app to test this: https://github.com/GrapheneOS/os-issue-tracker/issues/8548#issuecomment-5321318985